### PR TITLE
feat/argscheck

### DIFF
--- a/client.go
+++ b/client.go
@@ -130,11 +130,12 @@ func (a APIMethod[R, T]) Do(c Doer, input ...any) (*T, error) {
 		baseURL = b.BaseURL()
 	}
 	output := new(T)
+	args, others := splitArgs(string(a), input...)
 	resp, err := makeRequest(
 		c,
 		method.Method(),
-		fmt.Sprintf(baseURL+string(a), input...),
-		input..., // is there header/body handling required?
+		fmt.Sprintf(baseURL+string(a), args...),
+		others..., // is there header/body handling required?
 	)
 	if err != nil {
 		return nil, err

--- a/util.go
+++ b/util.go
@@ -1,0 +1,41 @@
+package rest
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+)
+
+var formatRegexp = regexp.MustCompile(`%[-+#0-9\.]*[a-z]`)
+
+// splitArgs separates the arguments that are used in the format string from
+// the arguments that are not used in the format string.
+// The format string is expected to be a valid format string for fmt.Sprintf.
+// The input arguments after any format arguments are expected to be of type io.Reader or http.Header.
+
+func splitArgs(s string, input ...any) ([]any, []any) {
+	var args []any
+	var notargs []any
+
+	matches := formatRegexp.FindAllStringIndex(s, -1)
+	matchpos := 0
+	for _, arg := range input {
+		for matchpos < len(matches) &&
+			s[matches[matchpos][0]-1] == '%' {
+			matchpos++
+		}
+		if matchpos < len(matches) {
+			args = append(args, arg)
+			matchpos++
+		} else {
+			switch v := arg.(type) {
+			case io.Reader, http.Header:
+				notargs = append(notargs, arg)
+			default:
+				panic(fmt.Errorf("unexpected type after format string: %T", v))
+			}
+		}
+	}
+	return args, notargs
+}

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,58 @@
+package rest
+
+import (
+	"bytes"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestSplitArgs(t *testing.T) {
+	tests := []struct {
+		name          string
+		s             string
+		inargs        []any
+		outputargs    []any
+		outputnotargs []any
+	}{
+		{
+			name:          "no args, header",
+			s:             "no args",
+			inargs:        []any{http.Header{"key": []string{"value"}}},
+			outputargs:    nil,
+			outputnotargs: []any{http.Header{"key": []string{"value"}}},
+		},
+		{
+			name:          "one arg, body",
+			s:             "one arg %s",
+			inargs:        []any{"hello", NullCloser{bytes.NewBufferString("world")}},
+			outputargs:    []any{"hello"},
+			outputnotargs: []any{NullCloser{bytes.NewBufferString("world")}},
+		},
+		{
+			name:          "one floating point arg, body",
+			s:             "one arg %-0.2f",
+			inargs:        []any{3.14159, NullCloser{bytes.NewBufferString("world")}},
+			outputargs:    []any{3.14159},
+			outputnotargs: []any{NullCloser{bytes.NewBufferString("world")}},
+		},
+		{
+			name:          "escaped percent sign",
+			s:             "100%%-smile %s",
+			inargs:        []any{"confident", http.Header{"key": []string{"value"}}},
+			outputargs:    []any{"confident"},
+			outputnotargs: []any{http.Header{"key": []string{"value"}}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args, notargs := splitArgs(tt.s, tt.inargs...)
+			if got, want := args, tt.outputargs; !reflect.DeepEqual(got, want) {
+				t.Errorf("got %#v, want %#v", got, want)
+			}
+			if got, want := notargs, tt.outputnotargs; !reflect.DeepEqual(got, want) {
+				t.Errorf("got %#v, want %#v", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
added a splitter to ensure the number of args is split between url and request correctly.
tests for same.

```
faye@MaxbookPro go-rest % go test -v
=== RUN   TestClient
=== RUN   TestClient/BaseURL
=== RUN   TestClient/BaseURL/returns_the_base_URL
--- PASS: TestClient (0.00s)
    --- PASS: TestClient/BaseURL (0.00s)
        --- PASS: TestClient/BaseURL/returns_the_base_URL (0.00s)
=== RUN   TestAPIMethod
=== RUN   TestAPIMethod/Do
=== RUN   TestAPIMethod/Do/makes_a_request
--- PASS: TestAPIMethod (0.00s)
    --- PASS: TestAPIMethod/Do (0.00s)
        --- PASS: TestAPIMethod/Do/makes_a_request (0.00s)
=== RUN   TestSplitArgs
=== RUN   TestSplitArgs/no_args,_header
=== RUN   TestSplitArgs/one_arg,_body
=== RUN   TestSplitArgs/one_floating_point_arg,_body
=== RUN   TestSplitArgs/escaped_percent_sign
--- PASS: TestSplitArgs (0.00s)
    --- PASS: TestSplitArgs/no_args,_header (0.00s)
    --- PASS: TestSplitArgs/one_arg,_body (0.00s)
    --- PASS: TestSplitArgs/one_floating_point_arg,_body (0.00s)
    --- PASS: TestSplitArgs/escaped_percent_sign (0.00s)
=== RUN   Example
--- PASS: Example (0.00s)
PASS
ok  	github.com/fayep/go-rest	0.166s
```